### PR TITLE
Add feature required with rustc 2018-03-20 nightly

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -63,8 +63,10 @@ fn find_existing(b: &mut Bencher) {
         m.insert(i, i);
     }
 
-    b.iter(|| for i in 1..1001 {
-        m.contains_key(&i);
+    b.iter(|| {
+        for i in 1..1001 {
+            m.contains_key(&i);
+        }
     });
 }
 
@@ -78,8 +80,10 @@ fn find_nonexisting(b: &mut Bencher) {
         m.insert(i, i);
     }
 
-    b.iter(|| for i in 1001..2001 {
-        m.contains_key(&i);
+    b.iter(|| {
+        for i in 1001..2001 {
+            m.contains_key(&i);
+        }
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(allocator_api)]
 #![feature(dropck_eyepatch)]
 #![feature(generic_param_attrs)]
+#![feature(hashmap_internals)]
 #![feature(placement_in_syntax)]
 #![feature(placement_new_protocol)]
 #![feature(ptr_internals)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -3575,7 +3575,7 @@ mod test_map {
         let mut m = HashMap::new();
         assert_eq!(m.remove_at_index(0), None);
         assert!(m.insert(1, 2).is_none());
-        assert_eq!(m.remove_at_index(5), Some((1,2)));
+        assert_eq!(m.remove_at_index(5), Some((1, 2)));
         assert!(m.insert(2, 4).is_none());
         assert!(m.insert(3, 8).is_none());
         let v = m.remove_at_index(0).unwrap();


### PR DESCRIPTION
`hashmap_internals` is required for rahashmap to compile.