### PR TITLE
Add at_index random accessor method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1464,6 +1464,23 @@ where
             probe = empty.next();
         }
     }
+
+    /// Return a random element in the bucket at a specific index.
+    pub fn at_index(&self, index: usize) -> Option<(&K, &V)> {
+        if self.is_empty() {
+            return None;
+        }
+
+        let mut probe = Bucket::at_index(&self.table, index);
+        loop {
+            let empty = match probe.peek() {
+                Full(elem) => return Some(elem.into_refs()),
+                Empty(empty) => empty,
+            };
+
+            probe = empty.next();
+        }
+    }
 }
 
 impl<K, V, S> PartialEq for HashMap<K, V, S>
@@ -3737,4 +3754,14 @@ mod test_map {
         assert!(v != w);
     }
 
+    #[test]
+    fn test_at_index() {
+        let mut m = HashMap::new();
+        assert_eq!(m.at_index(0), None);
+        assert!(m.insert(1, 2).is_none());
+        assert_eq!(m.at_index(5), Some((&1, &2)));
+        assert!(m.insert(2, 4).is_none());
+        let v = m.at_index(0).unwrap();
+        assert!(v == (&1, &2) || v == (&2, &4));
+    }
 }


### PR DESCRIPTION
As a complement to `remove_at_index`, using a similar API.

Useful for pre-eviction checks (e.g., for entry size or value). We need this to be able to evict from readers in distributary, see https://github.com/mit-pdos/distributary/commit/1755bcab8f3a827d14c63486e4e8f62cb4054220.