### PR TITLE
Fix build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rahashmap"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Jonathan Behrens <fintelia@gmail.com>", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = "Fork of standard library HashMap with additional functionality."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(ptr_internals)]
 #![feature(test)]
 #![feature(try_reserve)]
+#![feature(alloc_layout_extra)]
 
 extern crate rand;
 


### PR DESCRIPTION
hello, 
i'm just added a new macro, provided by compiler hint in order to compile with rust nightly 1.30.x : `use of unstable library feature 'alloc_layout_extra' (see issue #55724)`

If you are ok with this could you release this crate soon?